### PR TITLE
build: 🧱 update compiler flags in CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(Arkanoid LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_EXPORT_COMPILE_COMMANDS True)
-set(CMAKE_CXX_STANDARD 17)
+add_library(arkanoid_compiler_flags INTERFACE)
+target_compile_features(arkanoid_compiler_flags INTERFACE cxx_std_17)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 find_package(
@@ -29,10 +30,11 @@ target_link_libraries(
     sfml-audio
     sfml-graphics
     sfml-window
-    sfml-system)
+    sfml-system
+    arkanoid_compiler_flags)
 
 add_executable(Arkanoid src/arkanoid.cpp)
-target_link_libraries(Arkanoid PUBLIC Ball_lib)
+target_link_libraries(Arkanoid PUBLIC Ball_lib arkanoid_compiler_flags)
 target_include_directories(Arkanoid PUBLIC "${PROJECT_BINARY_DIR}")
 
 if(WIN32)

--- a/Catch_tests/CMakeLists.txt
+++ b/Catch_tests/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 add_executable(Catch_tests_run BallTests.cpp)
 
-target_link_libraries(Catch_tests_run PRIVATE Ball_lib)
+target_link_libraries(Catch_tests_run PUBLIC Ball_lib arkanoid_compiler_flags)
 target_link_libraries(Catch_tests_run PRIVATE Catch2::Catch2WithMain)
 target_include_directories(Catch_tests_run PUBLIC "${PROJECT_SOURCE_DIR}/src")
 


### PR DESCRIPTION
# Description

Use more modern approach to specify C++ standard in compiler flags, using CMake APIs.

## Type of change

- [X] Build

# How Has This Been Tested?

- [X] All Catch2 unit tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
