### PR TITLE
fix: 💫 add paddle collisions

### DIFF
--- a/src/arkanoid.cpp
+++ b/src/arkanoid.cpp
@@ -5,6 +5,34 @@
 #include "Ball.h"
 #include "Paddle.h"
 
+template <class T1, class T2>
+bool is_intersecting(const T1 &mObjectA, const T2 &mObjectB)
+{
+    return mObjectA.right() >= mObjectB.left() &&
+           mObjectA.left() <= mObjectB.right() &&
+           mObjectA.bottom() >= mObjectB.top() &&
+           mObjectA.top() <= mObjectB.bottom();
+}
+
+void handle_collision(const Paddle &mPaddle, Ball &mBall)
+{
+    if (!is_intersecting(mPaddle, mBall))
+    {
+        return;
+    }
+
+    mBall.velocity.y = -constants::kBallVelocity;
+
+    if (mBall.x() < mPaddle.x())
+    {
+        mBall.velocity.x = -constants::kBallVelocity;
+    }
+    else
+    {
+        mBall.velocity.x = constants::kBallVelocity;
+    }
+}
+
 int main()
 {
     Ball ball{static_cast<int>(constants::kWindowWidth / 2),
@@ -12,7 +40,7 @@ int main()
     Paddle paddle{static_cast<int>(constants::kWindowWidth / 2),
                   constants::kWindowHeight - constants::kPaddleInsetBottom};
     sf::RenderWindow window{{constants::kWindowWidth, constants::kWindowHeight},
-                            "Arkanoid - 1"};
+                            "Arkanoid Clone"};
     window.setFramerateLimit(constants::kFramerateLimit);
 
     while (window.isOpen())
@@ -43,6 +71,8 @@ int main()
 
         ball.update();
         paddle.update();
+
+        handle_collision(paddle, ball);
 
         window.draw(ball.shape);
         window.draw(paddle.shape);


### PR DESCRIPTION
# Description

Add paddle collision, the ball bounces off it.  The ball bounes left, when it hits the left half of the paddle, and right, when it his the right half.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] All Catch2 unit tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
