### PR TITLE
fix: 💫 set ball to move left or right, intially at random

### DIFF
--- a/src/entities.cpp
+++ b/src/entities.cpp
@@ -18,8 +18,11 @@ void create_ball(flecs::world *world)
 
     ball.set<CollisionBox>(
         CollisionBox(constants::kBallRadius, constants::kBallRadius));
-    ball.set<Velocity>(
-        Velocity(-constants::kBallVelocity, -constants::kBallVelocity));
+
+    // Randomly set ball x direction
+    const float ball_x_velocity{constants::kBallVelocity -
+                                static_cast<float>(GetRandomValue(0, 1)) * 2.F};
+    ball.set<Velocity>(Velocity(ball_x_velocity, -constants::kBallVelocity));
 }
 
 void create_bricks(flecs::world *world)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,8 @@ int main()
 {
     flecs::world world;
 
+    // Seed the Raylib RNG used in the create_ball method
+    SetRandomSeed((unsigned int)time(nullptr));
     create_ball(&world);
     create_paddle(&world);
     create_bricks(&world);


### PR DESCRIPTION
# Description

Set ball to spawn moving either left or right, at random, when the game starts.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Catch2 tests run and passed

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
